### PR TITLE
library buttons transitions and eventlistener for click

### DIFF
--- a/src/css/small.css
+++ b/src/css/small.css
@@ -103,7 +103,7 @@ li {
   text-align: center;
 }
 .dropdown li:hover {
-  background-color: var(--primary-color);
+  background-color: var(--tertiary-color);
 }
 .library:hover .dropdown {
   display: block;
@@ -159,7 +159,8 @@ a:active {
   .menu li:hover {
     display: inline-block;
     background-color: var(--quaternary-color);
-    transition: 0.3s ease;
+    transition: 0.3s ease; 
+
   }
   .menu li + li {
     margin-top: 12px;
@@ -289,14 +290,22 @@ a:active {
   background-color: white;
   cursor: pointer;
   font-size: 18px;
+  border-radius: 8px;
 }
 
 /* Style the active class, and buttons on mouse-over */
-.active,
-.btn:hover {
+.active {
+  background-color: var(--quaternary-color);
+  color: white;
+  border-radius: 8px;
+  transform:scale(110%); 
+}
+ .btn:hover {
   background-color: var(--tertiary-color);
   color: white;
-}
+  border-radius: 8px;
+  transform:scale(125%);
+ }
 
 /* Design for results page search results */
 
@@ -343,6 +352,7 @@ a:active {
 .addToShelfButtons button:hover {
   background-color: var(--tertiary-color);
   color: rgb(100, 100, 100);
+  transition:0.3s ease;
 }
 
 .addToShelfButtons button:active {

--- a/src/js/library.js
+++ b/src/js/library.js
@@ -44,3 +44,18 @@ wantButton.addEventListener("click", () => {
 //   this.className += "active";
 //   });
 // }
+
+// Add active class to the current button (highlight it)
+var header = document.getElementById("MyLIB");
+var btns = header.getElementsByClassName("btn");
+for (var i = 0; i < btns.length; i++) {
+  btns[i].addEventListener("click", function() {
+  var current = document.getElementsByClassName("active");
+  current[0].className = current[0].className.replace(" active", "");
+  this.className += " active";
+  });
+}
+// 
+
+
+

--- a/src/library.html
+++ b/src/library.html
@@ -45,7 +45,7 @@
 
       <div class="wrapper">
         <div id="MyLIB">
-          <button class="btn">
+          <button class="btn active">
             <img
               src="./images/ReadingIcon.png"
               max

--- a/src/results.html
+++ b/src/results.html
@@ -15,7 +15,7 @@
     <link
       href="https://fonts.googleapis.com/css2?family=Lato:wght@300;700&family=Montserrat+Alternates:ital,wght@1,200&family=Roboto&display=swap"
       rel="stylesheet"
-      <!--
+      <!-
       Added
       to
       fix


### PR DESCRIPTION
This branch includes the library transitions and adds an event listener to the clicked library buttons only on the library page but not on the search page. 

I also modified the buttons to have rounded edges.

I also changed the drop-down menu to hover in a slightly different colour, rather than a strong contrasting colour.