### PR TITLE
fixed hamburger menu floating up

### DIFF
--- a/src/css/large.css
+++ b/src/css/large.css
@@ -35,6 +35,7 @@
   }
 
   .menu {
+    margin-top: 0;
     border: none;
     font-family: var(--font-body);
     font-size: 1.6rem;

--- a/src/css/small.css
+++ b/src/css/small.css
@@ -214,7 +214,7 @@ input[type="search"]:focus {
   max-width: 100px;
 }
 
-/* NAVBAR MENU */
+/* NAVBAR  */
 
 /* CSS hamburger */
 /* Hamburger */
@@ -278,7 +278,7 @@ input[type="checkbox"] {
 /* end css hamburger */
 
 .menu {
-  margin-top: 1em;
+  margin-top: 3.5em;
   display: flex;
   gap: 1em;
   font-size: 18px;


### PR DESCRIPTION
This PR fixes the hamburger menu from sliding too far up on the screen when it is open.

- [ ] Open the site in a small view
- [ ] make sure that each element in the header is visible when the menu is opened


There is an opaque layer in the smallest view that will have to be dealt with in another branch.