### PR TITLE
Cp font adjust

### DIFF
--- a/src/css/large.css
+++ b/src/css/large.css
@@ -35,7 +35,6 @@
   }
 
   .menu {
-    margin-top: 0;
     border: none;
     font-family: var(--font-body);
     font-size: 1.6rem;
@@ -149,7 +148,7 @@
     padding-left: 200px;
   }
   .banner2 img{
-    padding: 1rem 8rem;
+    padding: 1rem 10rem;
     align-items: center;
     max-width:60rem;
    }

--- a/src/css/small.css
+++ b/src/css/small.css
@@ -108,7 +108,7 @@ body {
   margin-bottom: 0.2rem;
 }
 .navbar ul {
-  font-family: var(--font-body);
+  font-family: var(--font-family);
 }
 /********************* START OF STYLING FOR THE SEARCH OPTIONS SELECTOR ********************/
 label {
@@ -116,6 +116,7 @@ label {
   padding: 0 1em;
   text-align: center;
   min-width: 51px;
+  color:var(--light-grey);
 }
 
 div.searchScopeContainer {
@@ -190,7 +191,7 @@ input[type='radio']:checked:after {
 }
 
 .bannerS h2 {
-  font-family: var(--font-body);
+  font-family: var(--font-he);
 }
 
 input[type="search"] {
@@ -366,7 +367,7 @@ footer a:active {
 
 .footerMenu {
   border: none;
-  font-family: var(--font-body);
+  font-family: var(--font-a);
   font-size: 1.6rem;
   text-align: center;
   align-items: center;
@@ -1003,6 +1004,7 @@ button.book_delete {
   /* color: var(--white); */
   /* border: 3px outset var(--white); */
   cursor: pointer;
+  border-radius: 8px;
 }
 
 .addToShelfButtons button.book_delete:hover {

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -21,7 +21,7 @@
   </div>
   <div class="column">
     <div class="footerMenu">
-      <li><a href="./index.html">Why CloudShelf</a></li>
+      <li><a href="./index.html">Home</a></li>
       <li><a href="./library.html">My Library</a></li>
       <li><a class="darkModeToggle dmModePointer">Dark Mode</a></li>
     </div>


### PR DESCRIPTION
Font adjustment to Sandbox in the body,

Architects daughter just for the nav text in header and footer, to create a consistent look with the library buttons. 
<img width="430" alt="Screen Shot 2022-06-01 at 11 57 22 PM" src="https://user-images.githubusercontent.com/80508806/171563852-0138560d-f4c4-4f17-a230-191000799121.png">
<img width="301" alt="Screen Shot 2022-06-01 at 11 57 17 PM" src="https://user-images.githubusercontent.com/80508806/171563862-a7792bfb-b7ff-4b56-9a32-6b49c56fa250.png">
<img width="277" alt="Screen Shot 2022-06-01 at 11 57 27 PM" src="https://user-images.githubusercontent.com/80508806/171563869-0a539c4d-607a-489c-a893-d9c87c6340e9.png">


Montserrat is used for the font that overlays the books image. The thicker font in white doesn't compete for the logo, but adds the needed contrast to stand out against the image. 
<img width="759" alt="Screen Shot 2022-06-02 at 12 06 02 AM" src="https://user-images.githubusercontent.com/80508806/171563840-63019d87-82ba-4669-a2f1-0beab1e2ba2b.png">

